### PR TITLE
Allows user to upvote/downvote own posts

### DIFF
--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -123,11 +123,6 @@ module.exports = function (Posts) {
     }
 
     async function unvote(pid, uid, type, voteStatus) {
-        const owner = await Posts.getPostField(pid, 'uid');
-        if (parseInt(uid, 10) === parseInt(owner, 10)) {
-            throw new Error('[[error:self-vote]]');
-        }
-
         if (type === 'downvote' || type === 'upvote') {
             await checkVoteLimitation(pid, uid, type);
         }

--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const meta = require('../meta');
 const db = require('../database');
 const flags = require('../flags');
@@ -122,7 +123,16 @@ module.exports = function (Posts) {
         return await vote(type, false, pid, uid, voteStatus);
     }
 
+    // async function unvote(pid: string, uid: number, type: string,
+    //  voteStatus: { upvoted: boolean, downvoted: boolean }): Promise<void>
     async function unvote(pid, uid, type, voteStatus) {
+        // assert function parameter types in the body
+        assert(typeof (pid), 'string');
+        assert(typeof (uid), 'number');
+        assert(typeof (type), 'string');
+        // specifically, voteStatus is of type { upvoted: boolean, downvoted: boolean }
+        assert(typeof (voteStatus), 'object');
+
         if (type === 'downvote' || type === 'upvote') {
             await checkVoteLimitation(pid, uid, type);
         }
@@ -131,6 +141,12 @@ module.exports = function (Posts) {
             return;
         }
 
+        // assert function return types in the body
+        assert(typeof (voteStatus.upvoted), 'boolean');
+        assert(typeof (pid), 'string');
+        assert(typeof (uid), 'number');
+        // specifically, voteStatus is of type { upvoted: boolean, downvoted: boolean }
+        assert(typeof (voteStatus), 'object');
         return await vote(voteStatus.upvoted ? 'downvote' : 'upvote', true, pid, uid, voteStatus);
     }
 


### PR DESCRIPTION
- Found location in code that does not users to vote on their own posts
- Removed code to prevent error message being called when user tries voting on their own post as well as the now unused code that resulted from the removal
- Added comments to document signature type, parameter types, and return types of function affected

resolves #11 

Before: 
<img width="1308" alt="Screen Shot 2024-02-11 at 8 17 59 PM" src="https://github.com/CMU-313/spring24-nodebb-nodebfs/assets/85699876/dd2634ab-5641-428f-a27b-8392d9bd321b">

After:
<img width="978" alt="Screen Shot 2024-02-12 at 1 19 36 AM" src="https://github.com/CMU-313/spring24-nodebb-nodebfs/assets/85699876/3d2831de-0aa5-49e6-9f1d-1ad4dddb499b">
