### PR TITLE
Anonymize users in group posts

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -25,6 +25,8 @@ PostObject:
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)
+    anonymous:
+      type: boolean
     user:
       type: object
       properties:

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -3,6 +3,7 @@
 const validator = require('validator');
 const nconf = require('nconf');
 
+const assert = require('assert');
 const meta = require('../meta');
 const groups = require('../groups');
 const user = require('../user');
@@ -29,7 +30,16 @@ groupsController.list = async function (req, res) {
     });
 };
 
+
+// groupsController.details
+// req - request object
+// res - response object
+// next - pass control to middleware
 groupsController.details = async function (req, res, next) {
+    assert(typeof req === 'object');
+    assert(typeof res === 'object');
+    assert(typeof next === 'function');
+
     const lowercaseSlug = req.params.slug.toLowerCase();
     if (req.params.slug !== lowercaseSlug) {
         if (res.locals.isAPI) {

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -73,10 +73,25 @@ groupsController.details = async function (req, res, next) {
     }
     groupData.isOwner = groupData.isOwner || isAdmin || (isGlobalMod && !groupData.system);
 
+    const postsAnonymous = posts.map(post => ({
+        ...post,
+        user: post.anonymous ?
+            {
+                uid: 0,
+                username: 'anonymous',
+                userslug: 'anonymous',
+                picture: null,
+                status: 'online',
+                displayname: 'Anonymous User',
+                'icon:text': 'A',
+                'icon:bgColor': '#3f51b5',
+            } : post.user,
+    }));
+
     res.render('groups/details', {
         title: `[[pages:group, ${groupData.displayName}]]`,
         group: groupData,
-        posts: posts,
+        posts: postsAnonymous,
         isAdmin: isAdmin,
         isGlobalMod: isGlobalMod,
         allowPrivateGroups: meta.config.allowPrivateGroups,

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -4,6 +4,7 @@
 const validator = require('validator');
 const _ = require('lodash');
 
+const assert = require('assert');
 const topics = require('../topics');
 const user = require('../user');
 const plugins = require('../plugins');
@@ -11,7 +12,15 @@ const categories = require('../categories');
 const utils = require('../utils');
 
 module.exports = function (Posts) {
+    // Posts.getPostSummaryByPids
+    // pids - array of post ids
+    // uid - user id
+    // options - object of different post options
+    // returns list of post summaries
     Posts.getPostSummaryByPids = async function (pids, uid, options) {
+        assert(typeof pids === 'object');
+        assert(typeof uid === 'number');
+        assert(typeof options === 'object');
         if (!Array.isArray(pids) || !pids.length) {
             return [];
         }
@@ -58,6 +67,8 @@ module.exports = function (Posts) {
 
         posts = await parsePosts(posts, options);
         const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
+
+        assert(typeof result.posts === 'object');
         return result.posts;
     };
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);

--- a/test/posts.js
+++ b/test/posts.js
@@ -717,7 +717,7 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.strictEqual(Boolean(data[0].anonymous).valueOf(), false);
+                assert.equal(data[0].anonymous, false);
                 done();
             });
         });
@@ -726,7 +726,7 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.strictEqual(Boolean(data[0].anonymous).valueOf(), true);
+                assert.equal(data[0].anonymous, true);
                 done();
             });
         });

--- a/test/posts.js
+++ b/test/posts.js
@@ -717,7 +717,7 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.strictEqual(Boolean(data[0].anonymous), false);
+                assert.strictEqual(Boolean(data[0].anonymous).valueOf(), false);
                 done();
             });
         });
@@ -726,7 +726,7 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.strictEqual(Boolean(data[0].anonymous), true);
+                assert.strictEqual(Boolean(data[0].anonymous).valueOf(), true);
                 done();
             });
         });

--- a/test/posts.js
+++ b/test/posts.js
@@ -716,7 +716,7 @@ describe('Post\'s', () => {
         it('should get anonymous property when post is non anonymous', (done) => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
-                assert(!data[0].anonymous);
+                assert.strictEqual(data[0].anonymous, false);
                 done();
             });
         });
@@ -724,7 +724,7 @@ describe('Post\'s', () => {
         it('should get anonymous property when post is anonymous', (done) => {
             posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
-                assert(data[0].anonymous);
+                assert.strictEqual(data[0].anonymous, true);
                 done();
             });
         });

--- a/test/posts.js
+++ b/test/posts.js
@@ -716,7 +716,8 @@ describe('Post\'s', () => {
         it('should get anonymous property when post is non anonymous', (done) => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
-                assert.strictEqual(data[0].anonymous, false);
+                assert(data[0].hasOwnProperty('anonymous'));
+                assert.strictEqual(Boolean(data[0].anonymous), false);
                 done();
             });
         });
@@ -724,7 +725,8 @@ describe('Post\'s', () => {
         it('should get anonymous property when post is anonymous', (done) => {
             posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
-                assert.strictEqual(data[0].anonymous, true);
+                assert(data[0].hasOwnProperty('anonymous'));
+                assert.strictEqual(Boolean(data[0].anonymous), true);
                 done();
             });
         });

--- a/test/posts.js
+++ b/test/posts.js
@@ -30,6 +30,7 @@ describe('Post\'s', () => {
     let globalModUid;
     let postData;
     let topicData;
+    let anonymousPostData;
     let cid;
 
     before((done) => {
@@ -64,11 +65,27 @@ describe('Post\'s', () => {
                 cid: results.category.cid,
                 title: 'Test Topic Title',
                 content: 'The content of test topic',
+                anonymous: false,
             }, (err, data) => {
                 if (err) {
                     return done(err);
                 }
                 postData = data.postData;
+                topicData = data.topicData;
+
+                groups.join('Global Moderators', globalModUid, done);
+            });
+            topics.post({
+                uid: results.voteeUid,
+                cid: results.category.cid,
+                title: 'Test Topic Title',
+                content: 'The content of test topic',
+                anonymous: true,
+            }, (err, data) => {
+                if (err) {
+                    return done(err);
+                }
+                anonymousPostData = data.postData;
                 topicData = data.topicData;
 
                 groups.join('Global Moderators', globalModUid, done);
@@ -698,8 +715,16 @@ describe('Post\'s', () => {
             });
         });
 
-        it('should get anonymous property', (done) => {
+        it('should get anonymous property when post is non anonymous', (done) => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
+                assert.ifError(err);
+                assert(!data[0].anonymous);
+                done();
+            });
+        });
+
+        it('should get anonymous property when post is anonymous', (done) => {
+            posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].anonymous);
                 done();

--- a/test/posts.js
+++ b/test/posts.js
@@ -87,8 +87,6 @@ describe('Post\'s', () => {
                 }
                 anonymousPostData = data.postData;
                 topicData = data.topicData;
-
-                groups.join('Global Moderators', globalModUid, done);
             });
         });
     });

--- a/test/posts.js
+++ b/test/posts.js
@@ -697,6 +697,14 @@ describe('Post\'s', () => {
                 done();
             });
         });
+
+        it('should get anonymous property', (done) => {
+            posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
+                assert.ifError(err);
+                assert(data[0].anonymous);
+                done();
+            });
+        });
     });
 
     it('should get recent poster uids', (done) => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -717,7 +717,11 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([postData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.equal(data[0].anonymous, false);
+                if (typeof data[0].anonymous === 'string') {
+                    assert.equal(data[0].anonymous, 'false');
+                } else {
+                    assert.equal(data[0].anonymous, false);
+                }
                 done();
             });
         });
@@ -726,7 +730,11 @@ describe('Post\'s', () => {
             posts.getPostSummaryByPids([anonymousPostData.pid], 0, {}, (err, data) => {
                 assert.ifError(err);
                 assert(data[0].hasOwnProperty('anonymous'));
-                assert.equal(data[0].anonymous, true);
+                if (typeof data[0].anonymous === 'string') {
+                    assert.equal(data[0].anonymous, 'true');
+                } else {
+                    assert.equal(data[0].anonymous, true);
+                }
                 done();
             });
         });


### PR DESCRIPTION
- Adds the anonymous field into post summaries in order to access it while viewing the posts of the recent group
- Create a dummy anonymous user to pass into the render of groups if anonymous is true
- Add automating testing for the anonymous field in post summaries
- Add type-checking assert statements into the relevant functions used for post summaries and group post renders
- Create anonymous field in PostObject schema

Resolves #5 

Before:
<img width="1187" alt="Screen Shot 2024-02-29 at 12 57 18 PM" src="https://github.com/CMU-313/spring24-nodebb-nodebfs/assets/43354492/7d6a504c-bdf7-4d61-8809-3e41b638c343">

After
<img width="1199" alt="Screen Shot 2024-02-29 at 12 54 56 PM" src="https://github.com/CMU-313/spring24-nodebb-nodebfs/assets/43354492/692b7133-d41b-42c9-86fd-56ec6b5f305a">


